### PR TITLE
Fix session handling for login and package creation

### DIFF
--- a/src/app/api/admin/packages/route.ts
+++ b/src/app/api/admin/packages/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { getSessionUser, hasAdminRights } from '@/lib/auth';
 import { randomUUID } from 'crypto';
@@ -52,7 +53,7 @@ export async function POST(req: Request) {
         title,
         slug,
         description: description || null,
-        price: price ? new prisma.Prisma.Decimal(price) : null,
+        price: price ? new Prisma.Decimal(price) : null,
         startDate: startDate || undefined,
         endDate: endDate || undefined,
         days: days || undefined,

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import bcrypt from 'bcryptjs';
 import { prisma } from '@/lib/prisma';
 
 const SESSION_COOKIE = 'session_id';
 const SESSION_DAYS = 7;
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
 
 export async function POST(req: Request) {
   try {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -14,7 +14,9 @@ export default function LoginPage() {
     e.preventDefault();
     setBusy(true); setErr(null);
     const r = await fetch('/api/auth/login', {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
       body: JSON.stringify({ email, password }),
     });
     const data = await r.json();

--- a/src/components/packages/AddPackageButton.tsx
+++ b/src/components/packages/AddPackageButton.tsx
@@ -12,7 +12,10 @@ export default function AddPackageButton() {
   useEffect(() => {
     (async () => {
       try {
-        const r = await fetch('/api/auth/me', { cache: 'no-store' });
+        const r = await fetch('/api/auth/me', {
+          cache: 'no-store',
+          credentials: 'include',
+        });
         const data = await r.json();
         const roles: string[] = data?.user?.roles ?? [];
         setCanAdd(roles.includes('admin') || roles.includes('superadmin'));

--- a/src/components/packages/AddPackageModal.tsx
+++ b/src/components/packages/AddPackageModal.tsx
@@ -71,7 +71,11 @@ export default function AddPackageModal({ open, onClose }: { open: boolean; onCl
       if (form.description) fd.append('description', form.description);
       form.images.forEach((img, i) => fd.append(`images[${i}]`, img));
 
-      const res = await fetch('/api/admin/packages', { method: 'POST', body: fd });
+      const res = await fetch('/api/admin/packages', {
+        method: 'POST',
+        body: fd,
+        credentials: 'include',
+      });
       if (!res.ok) {
         const j = await res.json().catch(() => ({}));
         throw new Error(j?.error || 'Falha ao criar pacote');


### PR DESCRIPTION
## Summary
- ensure client requests that create or rely on sessions send cookies so logins and admin actions persist
- force the login API route to run in the Node.js runtime for compatibility
- fix package creation to build Prisma Decimal values correctly

## Testing
- npm run lint *(fails: existing lint errors about explicit any types)*

------
https://chatgpt.com/codex/tasks/task_e_68dc657a9b608333adde4ee8fcbd3d10