### PR TITLE
Implement package CRUD flow for travel packages

### DIFF
--- a/src/app/api/admin/packages/[id]/route.ts
+++ b/src/app/api/admin/packages/[id]/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getSessionUser, hasAdminRights } from '@/lib/auth';
+import { unlink } from 'fs/promises';
+import path from 'path';
+
+export async function DELETE(_: Request, { params }: { params: { id: string } }) {
+  try {
+    const actor = await getSessionUser();
+    if (!actor) return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+    if (!hasAdminRights(actor.roles)) return NextResponse.json({ error: 'Sem permissão' }, { status: 403 });
+
+    const packageId = Number(params.id);
+    if (!Number.isInteger(packageId)) {
+      return NextResponse.json({ error: 'Identificador inválido' }, { status: 400 });
+    }
+
+    const existing = await prisma.package.findUnique({
+      where: { id: packageId },
+      include: { images: true },
+    });
+
+    if (!existing) {
+      return NextResponse.json({ error: 'Pacote não encontrado' }, { status: 404 });
+    }
+
+    await prisma.$transaction([
+      prisma.packageImage.deleteMany({ where: { packageId } }),
+      prisma.package.delete({ where: { id: packageId } }),
+    ]);
+
+    await Promise.all(
+      existing.images.map(async (image) => {
+        const relativePath = image.url.startsWith('/') ? image.url.slice(1) : image.url;
+        const fullPath = path.join(process.cwd(), 'public', relativePath);
+        try {
+          await unlink(fullPath);
+        } catch (err) {
+          console.warn('Não foi possível remover imagem do pacote', fullPath, err);
+        }
+      })
+    );
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('DELETE /api/admin/packages/[id]', error);
+    return NextResponse.json({ error: 'Erro ao excluir pacote' }, { status: 500 });
+  }
+}

--- a/src/app/api/packages/route.ts
+++ b/src/app/api/packages/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+const currencyFormatter = new Intl.NumberFormat('pt-BR', {
+  style: 'currency',
+  currency: 'BRL',
+});
+
+export async function GET() {
+  try {
+    const packages = await prisma.package.findMany({
+      where: { isActive: true },
+      orderBy: { createdAt: 'desc' },
+      include: { images: { orderBy: { order: 'asc' } } },
+    });
+
+    const data = packages.map((pkg) => ({
+      id: String(pkg.id),
+      nome: pkg.title,
+      resumo: pkg.location ?? pkg.description ?? undefined,
+      descricao: pkg.description ?? undefined,
+      preco: pkg.price ? currencyFormatter.format(pkg.price.toNumber()) : undefined,
+      dias: pkg.days ?? undefined,
+      dataIda: pkg.startDate ? pkg.startDate.toISOString() : undefined,
+      dataVolta: pkg.endDate ? pkg.endDate.toISOString() : undefined,
+      local: pkg.location ?? undefined,
+      imagens: pkg.images.map((img) => img.url),
+    }));
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('GET /api/packages', error);
+    return NextResponse.json({ error: 'Não foi possível carregar os pacotes' }, { status: 500 });
+  }
+}

--- a/src/components/FeaturedPackages.tsx
+++ b/src/components/FeaturedPackages.tsx
@@ -4,17 +4,11 @@ import { useState } from 'react';
 import { motion } from 'framer-motion';
 import PackageModal from './PackageModal';
 import type { PackageDTO } from '@/types/package';
+import { usePackages } from '@/hooks/usePackages';
 
 export default function FeaturedPackages() {
-  // ⚠️ Placeholders – troque por dados do DB (fetch ou props)
-  const items: PackageDTO[] = [
-    { id: 'p1', nome: '[Nome DB]', resumo: '[Resumo]', preco: '[Preço]', imagens: [] },
-    { id: 'p2', nome: '[Nome DB]', resumo: '[Resumo]', preco: '[Preço]', imagens: [] },
-    { id: 'p3', nome: '[Nome DB]', resumo: '[Resumo]', preco: '[Preço]', imagens: [] },
-    { id: 'p4', nome: '[Nome DB]', resumo: '[Resumo]', preco: '[Preço]', imagens: [] },
-    { id: 'p5', nome: '[Nome DB]', resumo: '[Resumo]', preco: '[Preço]', imagens: [] },
-    { id: 'p6', nome: '[Nome DB]', resumo: '[Resumo]', preco: '[Preço]', imagens: [] },
-  ];
+  const { packages, loading, error } = usePackages();
+  const items: PackageDTO[] = packages.slice(0, 6);
 
   const [open, setOpen] = useState(false);
   const [current, setCurrent] = useState<PackageDTO | null>(null);
@@ -34,6 +28,16 @@ export default function FeaturedPackages() {
           <p className="mt-2 text-gray-600">[Descrição curta (DB)]</p>
         </div>
 
+        {loading && (
+          <p className="text-center text-gray-500">Carregando pacotes em destaque…</p>
+        )}
+
+        {!loading && error && <p className="text-center text-red-500">{error}</p>}
+
+        {!loading && !error && items.length === 0 && (
+          <p className="text-center text-gray-500">Nenhum pacote cadastrado até o momento.</p>
+        )}
+
         <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-8">
           {items.map((it, idx) => (
             <motion.button
@@ -47,13 +51,20 @@ export default function FeaturedPackages() {
               className="text-left rounded-2xl overflow-hidden bg-white shadow-md hover:shadow-lg transition hover:-translate-y-1 focus:outline-none focus:ring-2 focus:ring-pink-300"
             >
               <div className="h-40 w-full bg-gray-200 flex items-center justify-center text-gray-500">
-                [Imagem do pacote]
+                {it.imagens?.[0] ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={it.imagens[0]} alt={it.nome} className="h-full w-full object-cover" />
+                ) : (
+                  'Imagem indisponível'
+                )}
               </div>
               <div className="p-5">
                 <h3 className="text-lg font-semibold">{it.nome || '[Nome DB]'}</h3>
-                <p className="mt-1 text-sm text-gray-600">{it.resumo || '[Resumo DB]'}</p>
+                <p className="mt-1 text-sm text-gray-600">
+                  {it.resumo || it.descricao || 'Descrição em breve.'}
+                </p>
                 <div className="mt-4 flex items-center justify-between">
-                  <span className="text-xl font-extrabold text-gray-900">{it.preco || '[Preço]'}</span>
+                  <span className="text-xl font-extrabold text-gray-900">{it.preco || 'Preço a consultar'}</span>
                   <span className="rounded-full px-3 py-1 text-white text-sm font-semibold
                                    bg-gradient-to-r from-pink-500 via-red-500 to-yellow-500 bg-[length:200%_200%] animate-gradient-x">
                     Ver detalhes

--- a/src/components/PackageModal.tsx
+++ b/src/components/PackageModal.tsx
@@ -152,7 +152,14 @@ export default function PackageModal({ open, onClose, data }: Props) {
                 <div>
                   <p className="text-sm text-gray-500">Resumo</p>
                   <p className="text-gray-800">
-                    {data.resumo || '[Resumo do pacote do DB]'}
+                    {data.resumo || data.descricao || 'Em breve adicionaremos um resumo para este pacote.'}
+                  </p>
+                </div>
+
+                <div>
+                  <p className="text-sm text-gray-500">Destino</p>
+                  <p className="text-gray-800">
+                    {data.local || 'Destino a definir'}
                   </p>
                 </div>
 
@@ -166,7 +173,7 @@ export default function PackageModal({ open, onClose, data }: Props) {
                   <div>
                     <p className="text-gray-500">Dias</p>
                     <p className="font-semibold text-gray-900">
-                      {data.dias ?? '[Qtd dias DB]'}
+                      {data.dias ?? 'A definir'}
                     </p>
                   </div>
                   <div>
@@ -184,16 +191,9 @@ export default function PackageModal({ open, onClose, data }: Props) {
                 </div>
 
                 <div>
-                  <p className="text-sm text-gray-500">Evento / Observações</p>
-                  <p className="text-gray-800">
-                    {data.evento || '[Informações de evento do DB]'}
-                  </p>
-                </div>
-
-                <div>
                   <p className="text-sm text-gray-500">Sobre o lugar</p>
                   <p className="text-gray-800">
-                    {data.descricao || '[Texto sobre o destino (DB)]'}
+                    {data.descricao || 'Em breve adicionaremos uma descrição completa deste destino.'}
                   </p>
                 </div>
 

--- a/src/components/packages/AddPackageButton.tsx
+++ b/src/components/packages/AddPackageButton.tsx
@@ -1,27 +1,14 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { motion } from 'framer-motion';
 import { PlusIcon } from '@heroicons/react/24/outline';
 import AddPackageModal from './AddPackageModal';
+import { useCanManagePackages } from '@/hooks/useCanManagePackages';
 
 export default function AddPackageButton() {
-  const [canAdd, setCanAdd] = useState(false);
+  const canAdd = useCanManagePackages();
   const [open, setOpen] = useState(false);
-
-  useEffect(() => {
-    (async () => {
-      try {
-        const r = await fetch('/api/auth/me', {
-          cache: 'no-store',
-          credentials: 'include',
-        });
-        const data = await r.json();
-        const roles: string[] = data?.user?.roles ?? [];
-        setCanAdd(roles.includes('admin') || roles.includes('superadmin'));
-      } catch {}
-    })();
-  }, []);
 
   if (!canAdd) return null;
 

--- a/src/hooks/useCanManagePackages.ts
+++ b/src/hooks/useCanManagePackages.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function useCanManagePackages() {
+  const [canManage, setCanManage] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    (async () => {
+      try {
+        const response = await fetch('/api/auth/me', {
+          cache: 'no-store',
+          credentials: 'include',
+        });
+        if (!response.ok) return;
+        const data = await response.json();
+        const roles: string[] = data?.user?.roles ?? [];
+        if (!active) return;
+        setCanManage(roles.includes('admin') || roles.includes('superadmin'));
+      } catch (error) {
+        console.error('Erro ao verificar permissões do usuário', error);
+        if (active) setCanManage(false);
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return canManage;
+}
+
+export default useCanManagePackages;

--- a/src/hooks/usePackages.ts
+++ b/src/hooks/usePackages.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type { PackageDTO } from '@/types/package';
+
+export function usePackages() {
+  const [packages, setPackages] = useState<PackageDTO[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetch('/api/packages', { cache: 'no-store' });
+      if (!response.ok) throw new Error('Falha ao carregar pacotes');
+      const data = (await response.json()) as PackageDTO[];
+      setPackages(data);
+      setError(null);
+    } catch (err) {
+      console.error('Erro ao buscar pacotes', err);
+      setPackages([]);
+      setError('Não foi possível carregar os pacotes no momento.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const removeLocal = useCallback((id: string) => {
+    setPackages((prev) => prev.filter((pkg) => pkg.id !== id));
+  }, []);
+
+  return { packages, loading, error, reload: load, removeLocal };
+}
+
+export default usePackages;

--- a/src/types/package.ts
+++ b/src/types/package.ts
@@ -7,7 +7,7 @@ export type PackageDTO = {
   dias?: number;         // [Qtd de dias do DB]
   dataIda?: string;      // ISO (ex: 2025-12-01)
   dataVolta?: string;    // ISO (ex: 2025-12-05)
-  evento?: string;       // [Info de evento do DB]
+  local?: string;        // [Local/destino do DB]
   imagens?: string[];    // Até 5 URLs (ou caminhos do /public)
   // … acrescente campos que tiver no DB
 };


### PR DESCRIPTION
## Summary
- load travel packages from the database through a new public API endpoint and shared hook
- allow admins to delete packages and reuse permission checking logic across the UI
- refresh the packages grid and home highlights to display live package data, including improved modal details

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc6a5b9c6c8333ac954592ed130650