### PR TITLE
Fix cookie retrieval in admin user route

### DIFF
--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -7,7 +7,8 @@ import { prisma } from '@/lib/prisma';
 type Ctx = { params: { id: string } };
 
 async function getSessionUser() {
-  const sid = cookies().get('session_id')?.value;
+  const cookieStore = await cookies();
+  const sid = cookieStore.get('session_id')?.value;
   if (!sid) return null;
   const session = await prisma.authSession.findUnique({
     where: { id: sid },


### PR DESCRIPTION
## Summary
- await the Next.js cookies helper before reading the session id in the admin user route

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68dc715338008333bdf21953ee62d957