### PR TITLE
Fix register route to reuse shared Prisma client

### DIFF
--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from 'next/server';
-import { PrismaClient, Prisma } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import bcrypt from 'bcryptjs';
-
-const prisma = new PrismaClient();
+import { prisma } from '@/lib/prisma';
 
 /**
  * POST /api/auth/register


### PR DESCRIPTION
## Summary
- update the auth register API route to reuse the shared Prisma client helper
- prevent spawning a new PrismaClient instance on every request

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc715338008333bdf21953ee62d957