### PR TITLE
Persist superadmin page edits

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -114,3 +114,14 @@ model PackageImage {
   package   Package @relation(fields: [packageId], references: [id])
   packageId Int
 }
+
+model EditableContent {
+  id        Int      @id @default(autoincrement())
+  path      String
+  key       String
+  content   String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([path, key])
+}

--- a/src/app/api/content/route.ts
+++ b/src/app/api/content/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { prisma } from '@/lib/prisma';
+
+const SESSION_COOKIE = 'session_id';
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type SessionUser = { id: number; roles: string[] } | null;
+
+async function getSessionUser(): Promise<SessionUser> {
+  try {
+    const cookieStore = await cookies();
+    const sid = cookieStore.get(SESSION_COOKIE)?.value;
+    if (!sid) return null;
+
+    const session = await prisma.authSession.findUnique({
+      where: { id: sid },
+      include: { user: { include: { roles: { include: { role: true } } } } },
+    });
+
+    if (!session || session.expiresAt < new Date()) return null;
+
+    const roles = session.user.roles.map((r) => r.role.name);
+    return { id: session.user.id, roles };
+  } catch (error) {
+    console.error('Erro ao recuperar sessão', error);
+    return null;
+  }
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const path = searchParams.get('path');
+  const key = searchParams.get('key');
+
+  if (!path) {
+    return NextResponse.json({ error: 'Parâmetro "path" é obrigatório' }, { status: 400 });
+  }
+
+  try {
+    if (key) {
+      const entry = await prisma.editableContent.findUnique({
+        where: { path_key: { path, key } },
+      });
+      return NextResponse.json({ content: entry?.content ?? null }, { status: 200 });
+    }
+
+    const entries = await prisma.editableContent.findMany({
+      where: { path },
+      select: { key: true, content: true },
+    });
+
+    return NextResponse.json({ contents: entries }, { status: 200 });
+  } catch (error) {
+    console.error('Erro no GET /api/content', error);
+    return NextResponse.json({ error: 'Erro ao carregar conteúdos editáveis' }, { status: 500 });
+  }
+}
+
+type UpdatePayload = {
+  path: string;
+  key: string;
+  content: string;
+};
+
+export async function PUT(request: Request) {
+  const user = await getSessionUser();
+  if (!user) {
+    return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
+  }
+  if (!user.roles.includes('superadmin')) {
+    return NextResponse.json({ error: 'Sem permissão para salvar edições' }, { status: 403 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'JSON inválido' }, { status: 400 });
+  }
+
+  const updatesRaw = (body as { updates?: unknown })?.updates;
+  if (!Array.isArray(updatesRaw) || updatesRaw.length === 0) {
+    return NextResponse.json({ error: 'Nenhuma atualização enviada' }, { status: 400 });
+  }
+
+  const updates: UpdatePayload[] = [];
+  for (const item of updatesRaw) {
+    if (!item || typeof item !== 'object') continue;
+    const path = (item as { path?: unknown }).path;
+    const key = (item as { key?: unknown }).key;
+    const content = (item as { content?: unknown }).content;
+
+    if (typeof path !== 'string' || typeof key !== 'string') continue;
+    const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+    const normalizedContent =
+      typeof content === 'string' ? content : content !== undefined && content !== null ? String(content) : '';
+
+    updates.push({ path: normalizedPath, key, content: normalizedContent });
+  }
+
+  if (updates.length === 0) {
+    return NextResponse.json({ error: 'Nenhum conteúdo válido para atualizar' }, { status: 400 });
+  }
+
+  try {
+    const persisted = await Promise.all(
+      updates.map((update) =>
+        prisma.editableContent.upsert({
+          where: { path_key: { path: update.path, key: update.key } },
+          create: { path: update.path, key: update.key, content: update.content },
+          update: { content: update.content },
+        })
+      )
+    );
+
+    return NextResponse.json(
+      {
+        updated: persisted.map((item) => ({
+          path: item.path,
+          key: item.key,
+          content: item.content,
+          updatedAt: item.updatedAt,
+        })),
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error('Erro no PUT /api/content', error);
+    return NextResponse.json({ error: 'Erro ao salvar conteúdos' }, { status: 500 });
+  }
+}

--- a/src/app/pacotes/page.tsx
+++ b/src/app/pacotes/page.tsx
@@ -8,6 +8,7 @@ import type { PackageDTO } from '@/types/package';
 import { usePackages } from '@/hooks/usePackages';
 import { useCanManagePackages } from '@/hooks/useCanManagePackages';
 import { useEditMode } from '@/hooks/useEditMode';
+import EditableText from '@/components/EditableText';
 
 export default function PacotesPage() {
   const { packages: pacotes, loading, error, removeLocal } = usePackages();
@@ -90,22 +91,30 @@ export default function PacotesPage() {
           <div className="max-w-6xl mx-auto px-6 w-full">
             <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
               <div>
-                <motion.h1
+                <motion.div
                   initial={{ opacity: 0, y: 10 }}
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ duration: 0.6 }}
-                  className="text-4xl md:text-5xl font-extrabold text-white drop-shadow"
                 >
-                  [Título Pacotes (DB)]
-                </motion.h1>
-                <motion.p
+                  <EditableText
+                    as="h1"
+                    id="packages.hero.title"
+                    defaultContent="[Título Pacotes (DB)]"
+                    className="text-4xl md:text-5xl font-extrabold text-white drop-shadow"
+                  />
+                </motion.div>
+                <motion.div
                   initial={{ opacity: 0, y: 10 }}
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ delay: 0.1, duration: 0.6 }}
-                  className="mt-3 max-w-2xl text-white/90"
                 >
-                  [Descrição curta (DB)]
-                </motion.p>
+                  <EditableText
+                    as="p"
+                    id="packages.hero.subtitle"
+                    defaultContent="[Descrição curta (DB)]"
+                    className="mt-3 max-w-2xl text-white/90"
+                  />
+                </motion.div>
               </div>
 
               {/* ✅ Botão visível só para admin/superadmin (AddPackageButton faz a checagem) */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import dynamic from 'next/dynamic';
 import { motion } from 'framer-motion';
 import Link from 'next/link';
+import EditableText from '@/components/EditableText';
 
 // Import dinâmico (evita SSR de framer-motion em alguns hosts)
 const HeroSearch = dynamic(() => import('@/components/HeroSearch'), { ssr: false });
@@ -24,24 +25,32 @@ export default function HomePage() {
       {/* CTA final */}
       <section className="bg-white/90 backdrop-blur-sm">
         <div className="max-w-6xl mx-auto px-6 py-20 text-center">
-          <motion.h2
+          <motion.div
             initial={{ opacity: 0, y: 12 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.5 }}
-            className="text-3xl md:text-4xl font-extrabold"
           >
-            [Título da chamada final (DB)]
-          </motion.h2>
-          <motion.p
+            <EditableText
+              as="h2"
+              id="home.final.title"
+              defaultContent="[Título da chamada final (DB)]"
+              className="text-3xl md:text-4xl font-extrabold"
+            />
+          </motion.div>
+          <motion.div
             initial={{ opacity: 0, y: 8 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ delay: 0.1, duration: 0.5 }}
-            className="mt-3 text-gray-600 max-w-2xl mx-auto"
           >
-            [Descrição curta da chamada final (DB)]
-          </motion.p>
+            <EditableText
+              as="p"
+              id="home.final.description"
+              defaultContent="[Descrição curta da chamada final (DB)]"
+              className="mt-3 text-gray-600 max-w-2xl mx-auto"
+            />
+          </motion.div>
 
           <motion.div
             initial={{ opacity: 0, y: 8 }}
@@ -56,7 +65,11 @@ export default function HomePage() {
               bg-gradient-to-r from-pink-500 via-red-500 to-yellow-500 bg-[length:200%_200%]
               shadow-md hover:shadow-lg transition-all duration-500 hover:scale-[1.02] animate-gradient-x"
             >
-              [CTA ver pacotes (DB)]
+              <EditableText
+                as="span"
+                id="home.final.cta"
+                defaultContent="[CTA ver pacotes (DB)]"
+              />
             </Link>
           </motion.div>
         </div>

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import EditableText from '@/components/EditableText';
 
 export default function SobrePage() {
   const [mounted, setMounted] = useState(false);
@@ -17,29 +18,44 @@ export default function SobrePage() {
           mounted ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
         }`}
       >
-        <h1 className="text-4xl md:text-5xl font-extrabold mb-6">
-          {/* Título vindo do banco */}
-          [Título do Banco]
-        </h1>
-        <p className="text-lg md:text-xl text-gray-600 max-w-3xl mx-auto">
-          {/* Subtítulo/descrição vindo do banco */}
-          [Descrição curta do Banco]
-        </p>
+        <EditableText
+          as="h1"
+          id="about.hero.title"
+          defaultContent="[Título do Banco]"
+          className="text-4xl md:text-5xl font-extrabold mb-6"
+        />
+        <EditableText
+          as="p"
+          id="about.hero.subtitle"
+          defaultContent="[Descrição curta do Banco]"
+          className="text-lg md:text-xl text-gray-600 max-w-3xl mx-auto"
+        />
       </section>
 
       {/* Nossa História */}
       <section className="max-w-5xl mx-auto px-6 py-12 grid md:grid-cols-2 gap-12 items-center">
         <div className="space-y-4">
-          <h2 className="text-2xl font-bold">Nossa História</h2>
-          <p className="text-gray-600 leading-relaxed">
-            {/* Texto de história vindo do banco */}
-            [Texto História do Banco]
-          </p>
+          <EditableText
+            as="h2"
+            id="about.history.title"
+            defaultContent="Nossa História"
+            className="text-2xl font-bold"
+          />
+          <EditableText
+            as="p"
+            id="about.history.content"
+            defaultContent="[Texto História do Banco]"
+            className="text-gray-600 leading-relaxed"
+          />
         </div>
         <div className="rounded-xl overflow-hidden shadow-lg">
           {/* Imagem do banco */}
           <div className="w-full h-64 bg-gray-200 flex items-center justify-center text-gray-500">
-            [Imagem do Banco]
+            <EditableText
+              as="span"
+              id="about.history.image"
+              defaultContent="[Imagem do Banco]"
+            />
           </div>
         </div>
       </section>
@@ -47,9 +63,12 @@ export default function SobrePage() {
       {/* Valores */}
       <section className="bg-white/80 backdrop-blur-sm py-16">
         <div className="max-w-6xl mx-auto px-6">
-          <h2 className="text-2xl md:text-3xl font-bold text-center mb-12">
-            Nossos Valores
-          </h2>
+          <EditableText
+            as="h2"
+            id="about.values.title"
+            defaultContent="Nossos Valores"
+            className="text-2xl md:text-3xl font-bold text-center mb-12"
+          />
           <div className="grid md:grid-cols-3 gap-8">
             {/* Loop com valores vindos do banco */}
             {[1, 2, 3].map((i) => (
@@ -57,11 +76,24 @@ export default function SobrePage() {
                 key={i}
                 className="bg-white rounded-xl shadow-md p-8 text-center"
               >
-                <div className="text-4xl mb-4">[Ícone {i}]</div>
-                <h3 className="text-xl font-semibold mb-2">
-                  [Título Valor {i}]
-                </h3>
-                <p className="text-gray-600">[Descrição Valor {i}]</p>
+                <EditableText
+                  as="div"
+                  id={`about.values.${i}.icon`}
+                  defaultContent={`[Ícone ${i}]`}
+                  className="text-4xl mb-4"
+                />
+                <EditableText
+                  as="h3"
+                  id={`about.values.${i}.title`}
+                  defaultContent={`[Título Valor ${i}]`}
+                  className="text-xl font-semibold mb-2"
+                />
+                <EditableText
+                  as="p"
+                  id={`about.values.${i}.description`}
+                  defaultContent={`[Descrição Valor ${i}]`}
+                  className="text-gray-600"
+                />
               </div>
             ))}
           </div>
@@ -70,9 +102,12 @@ export default function SobrePage() {
 
       {/* Equipe */}
       <section className="max-w-6xl mx-auto px-6 py-16">
-        <h2 className="text-2xl md:text-3xl font-bold text-center mb-12">
-          Nossa Equipe
-        </h2>
+        <EditableText
+          as="h2"
+          id="about.team.title"
+          defaultContent="Nossa Equipe"
+          className="text-2xl md:text-3xl font-bold text-center mb-12"
+        />
         <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-10">
           {/* Loop equipe vindo do banco */}
           {[1, 2, 3].map((i) => (
@@ -81,11 +116,25 @@ export default function SobrePage() {
               className="bg-white rounded-xl shadow-md overflow-hidden"
             >
               <div className="w-full h-56 bg-gray-200 flex items-center justify-center text-gray-500">
-                [Foto {i}]
+                <EditableText
+                  as="span"
+                  id={`about.team.${i}.photo`}
+                  defaultContent={`[Foto ${i}]`}
+                />
               </div>
               <div className="p-4 text-center">
-                <h3 className="font-semibold text-lg">[Nome {i}]</h3>
-                <p className="text-gray-500 text-sm">[Cargo {i}]</p>
+                <EditableText
+                  as="h3"
+                  id={`about.team.${i}.name`}
+                  defaultContent={`[Nome ${i}]`}
+                  className="font-semibold text-lg"
+                />
+                <EditableText
+                  as="p"
+                  id={`about.team.${i}.role`}
+                  defaultContent={`[Cargo ${i}]`}
+                  className="text-gray-500 text-sm"
+                />
               </div>
             </div>
           ))}

--- a/src/components/EditableText.tsx
+++ b/src/components/EditableText.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { memo, useEffect, useMemo, useRef, useState, type ElementType, type Ref } from 'react';
+import { usePathname } from 'next/navigation';
+import { useEditMode } from '@/hooks/useEditMode';
+
+type Props = {
+  id: string;
+  defaultContent: string;
+  as?: ElementType;
+  className?: string;
+};
+
+const contentCache = new Map<string, string>();
+
+function EditableTextBase({ id, defaultContent, as: component = 'span', className }: Props) {
+  const pathname = usePathname();
+  const { registerEditable, unregisterEditable } = useEditMode();
+  const [content, setContent] = useState(defaultContent);
+  const ref = useRef<HTMLElement | null>(null);
+  const registryKey = useMemo(() => `${pathname}::${id}`, [pathname, id]);
+
+  useEffect(() => {
+    contentCache.set(registryKey, content);
+  }, [content, registryKey]);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    registerEditable(registryKey, {
+      element: node,
+      path: pathname,
+      editableId: id,
+      setContent: (value: string) => {
+        setContent(value);
+        contentCache.set(registryKey, value);
+      },
+    });
+    return () => {
+      unregisterEditable(registryKey);
+    };
+  }, [id, pathname, registerEditable, unregisterEditable, registryKey]);
+
+  useEffect(() => {
+    let active = true;
+    const cached = contentCache.get(registryKey);
+    if (cached !== undefined) {
+      setContent(cached);
+      return () => {
+        active = false;
+      };
+    }
+
+    (async () => {
+      try {
+        const res = await fetch(
+          `/api/content?path=${encodeURIComponent(pathname)}&key=${encodeURIComponent(id)}`,
+          { cache: 'no-store' }
+        );
+        if (!res.ok) throw new Error('Falha ao carregar conteúdo');
+        const data = await res.json();
+        if (!active) return;
+        const value = typeof data?.content === 'string' && data.content !== null ? data.content : defaultContent;
+        setContent(value);
+        contentCache.set(registryKey, value);
+      } catch {
+        if (!active) return;
+        setContent(defaultContent);
+        contentCache.set(registryKey, defaultContent);
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [defaultContent, id, pathname, registryKey]);
+
+  const ComponentTag = component as ElementType;
+
+  return (
+    <ComponentTag
+      ref={ref as unknown as Ref<HTMLElement>}
+      className={className}
+      data-editable-id={id}
+      data-editable-path={pathname}
+      suppressHydrationWarning
+      dangerouslySetInnerHTML={{ __html: content }}
+    />
+  );
+}
+
+export default memo(EditableTextBase);

--- a/src/components/FeaturedPackages.tsx
+++ b/src/components/FeaturedPackages.tsx
@@ -5,6 +5,7 @@ import { motion } from 'framer-motion';
 import PackageModal from './PackageModal';
 import type { PackageDTO } from '@/types/package';
 import { usePackages } from '@/hooks/usePackages';
+import EditableText from './EditableText';
 
 export default function FeaturedPackages() {
   const { packages, loading, error } = usePackages();
@@ -22,10 +23,18 @@ export default function FeaturedPackages() {
     <>
       <section className="max-w-6xl mx-auto px-6 py-16">
         <div className="text-center mb-10">
-          <h2 className="text-3xl md:text-4xl font-extrabold text-gray-900">
-            [Título dos principais pacotes (DB)]
-          </h2>
-          <p className="mt-2 text-gray-600">[Descrição curta (DB)]</p>
+          <EditableText
+            as="h2"
+            id="home.packages.title"
+            defaultContent="[Título dos principais pacotes (DB)]"
+            className="text-3xl md:text-4xl font-extrabold text-gray-900"
+          />
+          <EditableText
+            as="p"
+            id="home.packages.subtitle"
+            defaultContent="[Descrição curta (DB)]"
+            className="mt-2 text-gray-600"
+          />
         </div>
 
         {loading && (

--- a/src/components/HeroSearch.tsx
+++ b/src/components/HeroSearch.tsx
@@ -8,6 +8,7 @@ import {
   MapPinIcon,
   PaperAirplaneIcon,
 } from '@heroicons/react/24/outline';
+import EditableText from '@/components/EditableText';
 
 type SearchForm = {
   origem: string;
@@ -44,12 +45,18 @@ export default function HeroSearch() {
       <div className="relative max-w-6xl mx-auto px-6 pt-28 pb-16">
         {/* Título + subtítulo */}
         <div className="text-center mb-10">
-          <h1 className="text-4xl md:text-6xl font-extrabold text-gray-900 mb-4">
-            [Título principal do banco]
-          </h1>
-          <p className="text-lg md:text-xl text-gray-600 max-w-2xl mx-auto">
-            [Descrição principal curta do banco]
-          </p>
+          <EditableText
+            as="h1"
+            id="home.hero.title"
+            defaultContent="[Título principal do banco]"
+            className="text-4xl md:text-6xl font-extrabold text-gray-900 mb-4"
+          />
+          <EditableText
+            as="p"
+            id="home.hero.subtitle"
+            defaultContent="[Descrição principal curta do banco]"
+            className="text-lg md:text-xl text-gray-600 max-w-2xl mx-auto"
+          />
         </div>
 
         {/* GRID: mobile 1 col, tablet 2 cols, desktop 6 cols */}
@@ -157,7 +164,12 @@ export default function HeroSearch() {
                          shadow-md hover:shadow-lg transition-all duration-500 hover:scale-[1.01] animate-gradient-x"
             >
               <PaperAirplaneIcon className="h-5 w-5 -rotate-45 transition-transform group-hover:-translate-y-0.5" />
-              [Texto botão do banco]
+              <EditableText
+                as="span"
+                id="home.hero.button"
+                defaultContent="[Texto botão do banco]"
+                className="inline"
+              />
             </button>
           </div>
         </form>

--- a/src/components/ImageCarousel.tsx
+++ b/src/components/ImageCarousel.tsx
@@ -2,11 +2,11 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
+import EditableText from '@/components/EditableText';
 
 type Slide = {
   id: string;
-  // Substituir por src, alt vindos do banco
-  placeholderLabel: string;
+  defaultContent: string;
 };
 
 const AUTOPLAY_MS = 3500;
@@ -14,9 +14,9 @@ const AUTOPLAY_MS = 3500;
 export default function ImageCarousel() {
   const [index, setIndex] = useState(0);
   const slides: Slide[] = [
-    { id: '1', placeholderLabel: '[Banner 1 do Banco]' },
-    { id: '2', placeholderLabel: '[Banner 2 do Banco]' },
-    { id: '3', placeholderLabel: '[Banner 3 do Banco]' },
+    { id: 'home.carousel.banner1', defaultContent: '[Banner 1 do Banco]' },
+    { id: 'home.carousel.banner2', defaultContent: '[Banner 2 do Banco]' },
+    { id: 'home.carousel.banner3', defaultContent: '[Banner 3 do Banco]' },
   ];
 
   const timer = useRef<number | null>(null);
@@ -42,7 +42,12 @@ export default function ImageCarousel() {
             transition={{ type: 'spring', stiffness: 90, damping: 18 }}
           >
             {/* Trocar por <Image src=... /> vindo do banco */}
-            {s.placeholderLabel}
+            <EditableText
+              as="span"
+              id={s.id}
+              defaultContent={s.defaultContent}
+              className="px-4 text-center"
+            />
           </motion.div>
         ))}
 

--- a/src/components/PackageModal.tsx
+++ b/src/components/PackageModal.tsx
@@ -5,6 +5,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { XMarkIcon, ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
 import { useState } from 'react';
 import type { PackageDTO } from '@/types/package';
+import EditableText from './EditableText';
 
 type Props = {
   open: boolean;
@@ -142,7 +143,11 @@ export default function PackageModal({ open, onClose, data }: Props) {
                   </>
                 ) : (
                   <div className="h-full w-full flex items-center justify-center text-gray-500">
-                    [Carrossel do DB (0 imagens)]
+                    <EditableText
+                      as="span"
+                      id="packages.modal.emptyGallery"
+                      defaultContent="[Carrossel do DB (0 imagens)]"
+                    />
                   </div>
                 )}
               </div>
@@ -167,7 +172,13 @@ export default function PackageModal({ open, onClose, data }: Props) {
                   <div>
                     <p className="text-gray-500">Preço</p>
                     <p className="font-semibold text-gray-900">
-                      {data.preco || '[Preço do DB]'}
+                      {data.preco || (
+                        <EditableText
+                          as="span"
+                          id="packages.modal.pricePlaceholder"
+                          defaultContent="[Preço do DB]"
+                        />
+                      )}
                     </p>
                   </div>
                   <div>
@@ -179,13 +190,29 @@ export default function PackageModal({ open, onClose, data }: Props) {
                   <div>
                     <p className="text-gray-500">Ida</p>
                     <p className="font-semibold text-gray-900">
-                      {data.dataIda ? new Date(data.dataIda).toLocaleDateString() : '[Data ida DB]'}
+                      {data.dataIda ? (
+                        new Date(data.dataIda).toLocaleDateString()
+                      ) : (
+                        <EditableText
+                          as="span"
+                          id="packages.modal.departurePlaceholder"
+                          defaultContent="[Data ida DB]"
+                        />
+                      )}
                     </p>
                   </div>
                   <div>
                     <p className="text-gray-500">Volta</p>
                     <p className="font-semibold text-gray-900">
-                      {data.dataVolta ? new Date(data.dataVolta).toLocaleDateString() : '[Data volta DB]'}
+                      {data.dataVolta ? (
+                        new Date(data.dataVolta).toLocaleDateString()
+                      ) : (
+                        <EditableText
+                          as="span"
+                          id="packages.modal.returnPlaceholder"
+                          defaultContent="[Data volta DB]"
+                        />
+                      )}
                     </p>
                   </div>
                 </div>
@@ -203,7 +230,11 @@ export default function PackageModal({ open, onClose, data }: Props) {
                                bg-gradient-to-r from-pink-500 via-red-500 to-yellow-500 bg-[length:200%_200%]
                                shadow-md hover:shadow-lg hover:scale-[1.02] transition-all duration-500 animate-gradient-x"
                   >
-                    [CTA Reservar (DB)]
+                    <EditableText
+                      as="span"
+                      id="packages.modal.cta"
+                      defaultContent="[CTA Reservar (DB)]"
+                    />
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- add a Prisma EditableContent model and API endpoint to load and persist inline page edits
- extend the edit mode provider and introduce an EditableText helper that registers editable elements and saves changes through the new API
- replace static placeholders across the home, packages, about, and modal components with EditableText so superadmin edits become shared content

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc74f7ea5c8333870e8b5cd5aaa227