### PR TITLE
Create editable content table migration

### DIFF
--- a/prisma/migrations/20251001004715_add_editable_content/migration.sql
+++ b/prisma/migrations/20251001004715_add_editable_content/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "EditableContent" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "path" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EditableContent_path_key_key" ON "EditableContent"("path", "key");


### PR DESCRIPTION
## Summary
- add a migration that creates the EditableContent table used by the inline editor

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc79c1608c83339bd595557311a537