### PR TITLE
Ensure navbar reacts to authentication changes

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -22,9 +22,14 @@ export default function LoginPage() {
     const data = await r.json();
     setBusy(false);
     if (!r.ok) { setErr(data?.error ?? 'Falha no login'); return; }
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new Event('auth-change'));
+    }
     // Decide o destino por papel
     const roles: string[] = data?.roles ?? [];
-    router.push(roles.includes('admin') || roles.includes('superadmin') ? '/admin' : '/');
+    const destination = roles.includes('admin') || roles.includes('superadmin') ? '/admin' : '/';
+    router.push(destination);
+    router.refresh();
   };
 
   return (


### PR DESCRIPTION
## Summary
- refetch the current session when an auth-change event is emitted so the navbar updates immediately after login or logout
- dispatch the auth-change event during login/logout flows and refresh navigation so authenticated routes render promptly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc7a168ac88333833e0573aff73ab3