### PR TITLE
Fix lint issues and harden admin user flows

### DIFF
--- a/src/app/api/admin/packages/route.ts
+++ b/src/app/api/admin/packages/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { Prisma } from '@prisma/client';
 import { getSessionUser, hasAdminRights } from '@/lib/auth';
 import { randomUUID } from 'crypto';
 import { writeFile, mkdir } from 'fs/promises';
@@ -53,7 +54,7 @@ export async function POST(req: Request) {
         title,
         slug,
         description: description || null,
-        price: price ? new prisma.Prisma.Decimal(price) : null,
+        price: price ? new Prisma.Decimal(price) : null,
         startDate: startDate || undefined,
         endDate: endDate || undefined,
         days: days || undefined,

--- a/src/app/pacotes/page.tsx
+++ b/src/app/pacotes/page.tsx
@@ -355,12 +355,11 @@ export default function PacotesPage() {
                 key={p.id}
                 role="button"
                 tabIndex={0}
-                onClick={() => { setCurrent(p); setOpen(true); }}
+                onClick={() => abrir(p)}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter' || e.key === ' ') {
                     e.preventDefault();
-                    setCurrent(p);
-                    setOpen(true);
+                    abrir(p);
                   }
                 }}
                 initial={{ opacity: 0, y: 18 }}

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -188,12 +188,7 @@ export default function SobrePage() {
                 <div className="relative isolate rounded-3xl border border-white/20 bg-white/15 p-6 shadow-2xl backdrop-blur-xl ring-1 ring-white/20">
                   <div className="pointer-events-none absolute -inset-px rounded-3xl bg-gradient-to-br from-white/40 via-white/10 to-white/0" />
                   <div className="grid grid-cols-2 gap-4">
-                    {[
-                      { icon: Plane, title: 'Passagens' },
-                      { icon: Hotel, title: 'Hotéis' },
-                      { icon: Ship, title: 'Cruzeiros' },
-                      { icon: MapPin, title: 'Passeios' },
-                    ].map((s, i) => {
+                    {SERVICES.slice(0, 4).map((s, i) => {
                       const Icon = s.icon;
                       return (
                         <motion.div
@@ -270,7 +265,7 @@ export default function SobrePage() {
               { year: '2016', title: 'Rede global', text: 'Parcerias internacionais e curadoria mais robusta.' },
               { year: '2022', title: 'Expansão de serviços', text: 'Cruzeiros, experiências exclusivas e grupos.' },
               { year: 'Hoje', title: 'Próximo nível', text: 'Tecnologia + cuidado humano para escalar sem perder o toque.' },
-            ].map((t, i) => (
+            ].map((t) => (
               <li key={t.title}>
                 <div className="absolute -start-1.5 mt-1.5 h-3 w-3 rounded-full border border-white bg-pink-600" />
                 <time className="mb-1 block text-sm font-semibold text-pink-700">{t.year}</time>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -70,7 +70,11 @@ export default function Navbar() {
 
   const handleEditButtonClick = () => {
     if (!isSuperAdmin) return;
-    isEditing ? disableEdit() : enableEdit();
+    if (isEditing) {
+      disableEdit();
+    } else {
+      enableEdit();
+    }
     setMenuOpen(false);
   };
 

--- a/src/components/admin/CreateUserModal.tsx
+++ b/src/components/admin/CreateUserModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import type { ReactNode, RefObject } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import type { Role } from '@/hooks/useAdminUsers';
 import {
@@ -244,13 +245,13 @@ function Field({
   error,
   helper,
 }: {
-  icon: React.ReactNode;
+  icon: ReactNode;
   label: string;
   value: string;
   onChange: (v: string) => void;
   type?: string;
   placeholder?: string;
-  inputRef?: React.RefObject<HTMLInputElement>;
+  inputRef?: RefObject<HTMLInputElement | null>;
   required?: boolean;
   error?: boolean;
   helper?: string;

--- a/src/components/admin/UserManager.tsx
+++ b/src/components/admin/UserManager.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
+import type { KeyboardEvent, ReactNode } from 'react';
 import type { User } from '@/hooks/useAdminUsers';
 import {
   PlusCircleIcon,
@@ -41,8 +42,12 @@ export default function UserManager() {
       if (!res.ok) throw new Error('Falha ao carregar usuários');
       const data = (await res.json()) as User[];
       setUsers(data);
-    } catch (err: any) {
-      if (err?.name !== 'AbortError') setError(err?.message || 'Erro ao carregar usuários');
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        return;
+      }
+      const message = err instanceof Error ? err.message : 'Erro ao carregar usuários';
+      setError(message);
     } finally {
       if (!controller.signal.aborted) setLoading(false);
     }
@@ -105,15 +110,16 @@ export default function UserManager() {
       const newUser = data as User;
       setUsers((prev) => [...prev, newUser]);
       setForm({ name: '', email: '', phone: '' });
-    } catch (err: any) {
-      setError(err?.message || 'Erro ao criar usuário');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Erro ao criar usuário';
+      setError(message);
     } finally {
       setCreating(false);
     }
   };
 
   // submit com Enter no último input
-  const onKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const onKeyPress = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') createUser();
   };
 
@@ -354,13 +360,13 @@ function Field({
   error,
 }: {
   className?: string;
-  icon: React.ReactNode;
+  icon: ReactNode;
   value: string;
   onChange: (v: string) => void;
   type?: string;
   placeholder?: string;
   autoComplete?: string;
-  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
   error?: boolean;
 }) {
   return (


### PR DESCRIPTION
## Summary
- reuse existing helpers and data arrays in the marketing pages to satisfy lint rules
- tighten admin user management components with safer typing and ref handling
- correct Prisma decimal usage in the packages API to restore type safety

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd26e746c48333b599d3a6947a9ccf