### PR TITLE
Fix mobile navbar overlay layering

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -251,7 +251,7 @@ export default function Navbar() {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -8 }}
             transition={{ duration: 0.25 }}
-            className="md:hidden fixed left-0 right-0 mt-[var(--header-h)] px-3"
+            className="md:hidden fixed inset-x-0 top-[var(--header-h)] z-[60] px-3"
           >
             <div className="rounded-2xl bg-white/95 p-6 shadow-xl ring-1 ring-black/5 backdrop-blur">
               <div className="flex flex-col gap-3 text-[16px] font-medium text-gray-800">


### PR DESCRIPTION
## Summary
- ensure the mobile navigation overlay is positioned above page backgrounds by giving it a top offset and higher z-index

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd378182488333b4c7f2b2fdc74d3d