### PR TITLE
Fix admin package route context typing

### DIFF
--- a/src/app/api/admin/packages/[id]/route.ts
+++ b/src/app/api/admin/packages/[id]/route.ts
@@ -6,10 +6,10 @@ import path from 'path';
 
 export async function DELETE(
   _: Request,
-  context: { params: Promise<{ id: string }> }
+  context: { params: { id: string } }
 ) {
   try {
-    const { id } = await context.params;
+    const { id } = context.params;
     const actor = await getSessionUser();
     if (!actor) return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
     if (!hasAdminRights(actor.roles)) return NextResponse.json({ error: 'Sem permissão' }, { status: 403 });


### PR DESCRIPTION
## Summary
- update the admin package DELETE handler to use the expected Next.js context params typing

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd97e5b7bc83338f3f726c67523791