### PR TITLE
Fix DELETE handler typing for admin package route

### DIFF
--- a/src/app/api/admin/packages/[id]/route.ts
+++ b/src/app/api/admin/packages/[id]/route.ts
@@ -1,15 +1,15 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getSessionUser, hasAdminRights } from '@/lib/auth';
 import { unlink } from 'fs/promises';
 import path from 'path';
 
 export async function DELETE(
-  _: Request,
-  context: { params: { id: string } }
+  _: NextRequest,
+  context: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { id } = context.params;
+    const { id } = await context.params;
     const actor = await getSessionUser();
     if (!actor) return NextResponse.json({ error: 'Não autenticado' }, { status: 401 });
     if (!hasAdminRights(actor.roles)) return NextResponse.json({ error: 'Sem permissão' }, { status: 403 });


### PR DESCRIPTION
## Summary
- import NextRequest and update the DELETE handler signature to match Next.js expectations
- await the promised params object to extract the package id

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd9b657b288333ba6d5f29c5c5dd00