### PR TITLE
Fix PrismaClient import for create superadmin script

### DIFF
--- a/prisma/create-superadmin.ts
+++ b/prisma/create-superadmin.ts
@@ -1,6 +1,7 @@
-import { PrismaClient } from '@prisma/client';
+import prismaPkg from '@prisma/client';
 import bcrypt from 'bcrypt';
 
+const { PrismaClient } = prismaPkg as typeof import('@prisma/client');
 const prisma = new PrismaClient();
 
 async function main() {


### PR DESCRIPTION
## Summary
- update the Prisma client import in prisma/create-superadmin.ts to work even when the named export is unavailable
- keep the PrismaClient instantiation unchanged while preserving type safety

## Testing
- npx tsc --noEmit
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ddc5b91f5483338e64971a8330318d