### PR TITLE
Configure Prisma for Vercel Postgres

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# === Banco de dados ===
+# Para Vercel Postgres, copie POSTGRES_PRISMA_URL para DATABASE_URL e
+# POSTGRES_URL_NON_POOLING para DIRECT_URL.
+DATABASE_URL=""
+DIRECT_URL=""
+
+# Credenciais opcionais para o usuário superadministrador criado pelo seed
+ADMIN_EMAIL="admin@evastur.com"
+ADMIN_PASSWORD=""

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
+## Configurando o banco de dados (Prisma + Vercel)
+
+1. Crie um banco de dados online (ex.: [Vercel Postgres](https://vercel.com/docs/storage/vercel-postgres)).
+2. No painel da Vercel, copie os valores de `POSTGRES_PRISMA_URL` e `POSTGRES_URL_NON_POOLING` e defina-os nas variáveis do projeto:
+   - `DATABASE_URL` → cole o valor de `POSTGRES_PRISMA_URL` (string com pooling). É usada pelo app em produção.
+   - `DIRECT_URL` → cole o valor de `POSTGRES_URL_NON_POOLING` (string direta). É usada para migrações/seed.
+3. Opcional: ajuste `ADMIN_EMAIL` e `ADMIN_PASSWORD` para controlar o usuário criado pelo seed.
+4. Execute as migrações com `npx prisma migrate deploy` (produção) ou `npm run db:migrate` (dev).
+
+Depois disso, você já pode rodar o servidor de desenvolvimento localmente apontando para o banco online.
+
 First, run the development server:
 
 ```bash

--- a/prisma/create-superadmin.ts
+++ b/prisma/create-superadmin.ts
@@ -1,8 +1,22 @@
+import 'dotenv/config';
 import prismaPkg from '@prisma/client';
 import bcrypt from 'bcrypt';
 
 const { PrismaClient } = prismaPkg as typeof import('@prisma/client');
-const prisma = new PrismaClient();
+
+const connectionString =
+  process.env.DIRECT_URL ??
+  process.env.POSTGRES_URL_NON_POOLING ??
+  process.env.DATABASE_URL ??
+  process.env.POSTGRES_PRISMA_URL;
+
+if (!connectionString) {
+  throw new Error(
+    'Não encontramos uma string de conexão para o banco. Defina DIRECT_URL, POSTGRES_URL_NON_POOLING ou DATABASE_URL antes de criar o superadmin.',
+  );
+}
+
+const prisma = new PrismaClient({ datasources: { db: { url: connectionString } } });
 
 async function main() {
   const email = "admin@evastur.com";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,6 +5,7 @@ generator client {
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 /**

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,7 +1,20 @@
+import 'dotenv/config';
 import { PrismaClient } from '@prisma/client';
 import bcrypt from 'bcryptjs';
 
-const prisma = new PrismaClient();
+const connectionString =
+  process.env.DIRECT_URL ??
+  process.env.POSTGRES_URL_NON_POOLING ??
+  process.env.DATABASE_URL ??
+  process.env.POSTGRES_PRISMA_URL;
+
+if (!connectionString) {
+  throw new Error(
+    'Não encontramos uma string de conexão para o banco. Defina DIRECT_URL, POSTGRES_URL_NON_POOLING ou DATABASE_URL antes de rodar o seed.',
+  );
+}
+
+const prisma = new PrismaClient({ datasources: { db: { url: connectionString } } });
 
 async function main() {
   /* ========= 1) Permissões base ========= */

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -2,9 +2,22 @@ import { PrismaClient } from '@prisma/client';
 
 const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
 
+const connectionString =
+  process.env.POSTGRES_PRISMA_URL ??
+  process.env.DATABASE_URL ??
+  process.env.POSTGRES_URL ??
+  process.env.POSTGRES_URL_NON_POOLING;
+
+if (!connectionString) {
+  throw new Error(
+    'DATABASE_URL (ou POSTGRES_PRISMA_URL) não foi definido. Configure as variáveis de ambiente do banco antes de iniciar o app.',
+  );
+}
+
 export const prisma =
   globalForPrisma.prisma ??
   new PrismaClient({
+    datasources: { db: { url: connectionString } },
     log: process.env.NODE_ENV === 'development' ? ['query', 'error', 'warn'] : ['error'],
   });
 


### PR DESCRIPTION
## Summary
- add support for pooled and direct Prisma connection strings to run against Vercel Postgres
- ensure seed and superadmin scripts load .env configuration and reuse the online database URL
- document the required environment variables and ship an example .env file for deployment

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ddc85fd8a48333bc1c8f99becb13c9