### PR TITLE
Ensure default roles and seed data for package loading

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Prisma } from '@prisma/client';
 import bcrypt from 'bcryptjs';
 
 const connectionString =
@@ -116,7 +116,107 @@ async function main() {
     create: { userId: superUser.id, roleId: superadmin.id },
   });
 
-  console.log('✅ Seed concluído: roles & permissions + superadmin prontos.');
+  console.log('✅ Roles e permissões atualizados e superadmin pronto.');
+
+  /* ========= 5) Pacotes de exemplo ========= */
+  type PackageSeed = {
+    title: string;
+    slug: string;
+    description: string;
+    price: string;
+    startDate: Date;
+    endDate: Date;
+    days: number;
+    location: string;
+    images: string[];
+  };
+
+  const packagesSeed: PackageSeed[] = [
+    {
+      title: 'Paris Romântica',
+      slug: 'paris-romantica',
+      description:
+        'Sete noites em Paris com city tour completo, passeio pelo Rio Sena e visita guiada ao Louvre. Hospedagem em hotel 4 estrelas com café da manhã incluso.',
+      price: '7999.90',
+      startDate: new Date('2024-11-05'),
+      endDate: new Date('2024-11-12'),
+      days: 7,
+      location: 'Paris, França',
+      images: [
+        'https://images.unsplash.com/photo-1502602898657-3e91760cbb34?auto=format&fit=crop&w=1920&q=80',
+        'https://images.unsplash.com/photo-1491553895911-0055eca6402d?auto=format&fit=crop&w=1920&q=80',
+        'https://images.unsplash.com/photo-1467269204594-9661b134dd2b?auto=format&fit=crop&w=1920&q=80',
+      ],
+    },
+    {
+      title: 'Nordeste Essencial',
+      slug: 'nordeste-essencial',
+      description:
+        'Descubra os paraísos de Maceió e Maragogi com passeios às piscinas naturais, buggy nas dunas e experiência gastronômica regional. Inclui aéreo e traslados.',
+      price: '3899.00',
+      startDate: new Date('2024-10-18'),
+      endDate: new Date('2024-10-25'),
+      days: 7,
+      location: 'Maceió & Maragogi, Brasil',
+      images: [
+        'https://images.unsplash.com/photo-1526402460759-99adb65ab148?auto=format&fit=crop&w=1920&q=80',
+        'https://images.unsplash.com/photo-1512389142860-9c449e58a543?auto=format&fit=crop&w=1920&q=80',
+        'https://images.unsplash.com/photo-1496412705862-e0088f16f791?auto=format&fit=crop&w=1920&q=80',
+      ],
+    },
+    {
+      title: 'Aventura Andina',
+      slug: 'aventura-andina',
+      description:
+        'Experiência pelos Andes com passagem por Cusco, Valle Sagrado e Machu Picchu. Guia em português e ingressos inclusos. Perfeito para viajantes exploradores.',
+      price: '5299.50',
+      startDate: new Date('2024-09-07'),
+      endDate: new Date('2024-09-14'),
+      days: 7,
+      location: 'Cusco & Machu Picchu, Peru',
+      images: [
+        'https://images.unsplash.com/photo-1483721310020-03333e577078?auto=format&fit=crop&w=1920&q=80',
+        'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1920&q=80',
+        'https://images.unsplash.com/photo-1533636721434-0e2d61030955?auto=format&fit=crop&w=1920&q=80',
+      ],
+    },
+  ];
+
+  for (const pkg of packagesSeed) {
+    await prisma.package.upsert({
+      where: { slug: pkg.slug },
+      update: {
+        title: pkg.title,
+        description: pkg.description,
+        price: new Prisma.Decimal(pkg.price),
+        startDate: pkg.startDate,
+        endDate: pkg.endDate,
+        days: pkg.days,
+        location: pkg.location,
+        isActive: true,
+        images: {
+          deleteMany: {},
+          create: pkg.images.map((url, index) => ({ url, order: index })),
+        },
+      },
+      create: {
+        title: pkg.title,
+        slug: pkg.slug,
+        description: pkg.description,
+        price: new Prisma.Decimal(pkg.price),
+        startDate: pkg.startDate,
+        endDate: pkg.endDate,
+        days: pkg.days,
+        location: pkg.location,
+        isActive: true,
+        images: {
+          create: pkg.images.map((url, index) => ({ url, order: index })),
+        },
+      },
+    });
+  }
+
+  console.log('✅ Seed concluído: pacotes de exemplo disponíveis.');
 }
 
 main()

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -32,13 +32,11 @@ export async function POST(req: Request) {
     const passwordHash = await bcrypt.hash(password, 10);
 
     // Busca papel "comum"
-    const commonRole = await prisma.role.findUnique({ where: { name: 'comum' } });
-    if (!commonRole) {
-      return NextResponse.json(
-        { error: 'Papel "comum" não encontrado. Rode o seed novamente.' },
-        { status: 500 }
-      );
-    }
+    const commonRole = await prisma.role.upsert({
+      where: { name: 'comum' },
+      update: {},
+      create: { name: 'comum', description: 'Usuário padrão' },
+    });
 
     // Cria usuário e vincula papel "comum"
     const user = await prisma.user.create({

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -2,18 +2,24 @@ import { PrismaClient } from '@prisma/client';
 
 const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
 
-const resolveConnectionString = () =>
-  process.env.POSTGRES_PRISMA_URL ??
-  process.env.DATABASE_URL ??
-  process.env.POSTGRES_URL ??
-  process.env.POSTGRES_URL_NON_POOLING;
+const resolveConnectionString = () => {
+  const connection =
+    process.env.DATABASE_URL ??
+    process.env.POSTGRES_PRISMA_URL ??
+    process.env.POSTGRES_URL ??
+    process.env.POSTGRES_URL_NON_POOLING ??
+    process.env.DIRECT_URL ??
+    process.env.POSTGRES_DATABASE_URL;
+
+  return connection;
+};
 
 const getOrCreatePrismaClient = () => {
   const connectionString = resolveConnectionString();
 
   if (!connectionString) {
     throw new Error(
-      'DATABASE_URL (ou POSTGRES_PRISMA_URL) não foi definido. Configure as variáveis de ambiente do banco antes de iniciar o app.',
+      'Nenhuma variável de conexão com o banco foi encontrada. Defina DATABASE_URL, POSTGRES_PRISMA_URL, POSTGRES_URL, POSTGRES_URL_NON_POOLING, DIRECT_URL ou POSTGRES_DATABASE_URL antes de iniciar o app.',
     );
   }
 


### PR DESCRIPTION
## Summary
- allow the Prisma helper to resolve additional database connection environment variables with clearer errors
- ensure the registration flow always creates or reuses the "comum" role instead of failing when the seed was not executed
- extend the Prisma seed to populate sample travel packages so the home and packages pages have data available

## Testing
- npm run lint *(fails: missing @eslint/eslintrc in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de8d8e37388333990c24b4084e8e0f