### PR TITLE
Configure Prisma seed for automatic superadmin recreation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
    - `DATABASE_URL` → cole o valor de `POSTGRES_PRISMA_URL` (string com pooling). É usada pelo app em produção.
    - `DIRECT_URL` → cole o valor de `POSTGRES_URL_NON_POOLING` (string direta). É usada para migrações/seed.
 3. Opcional: ajuste `ADMIN_EMAIL` e `ADMIN_PASSWORD` para controlar o usuário criado pelo seed.
-4. Execute as migrações com `npx prisma migrate deploy` (produção) ou `npm run db:migrate` (dev).
+4. Execute as migrações com `npx prisma migrate deploy` (produção) ou `npm run db:migrate` (dev). Esse passo também dispara o `prisma db seed`, garantindo que o papel **superadmin** e o usuário inicial sejam recriados automaticamente após resets do banco.
 
 Depois disso, você já pode rodar o servidor de desenvolvimento localmente apontando para o banco online.
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   
     "vercel-build": "prisma generate --schema=prisma/schema.prisma && prisma migrate deploy --schema=prisma/schema.prisma && next build"
   },
+  "prisma": {
+    "seed": "ts-node --compiler-options '{\"module\":\"commonjs\",\"moduleResolution\":\"node\"}' prisma/seed.ts"
+  },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
     "@prisma/client": "^6.16.3",


### PR DESCRIPTION
## Summary
- configure Prisma's seed hook to execute the existing TypeScript seeding script so the superadmin role and user are recreated after migrations or resets
- document in the README that running migrations automatically triggers the seed process to provision the superadmin user

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de9c5d3518833398ef529430967bc1