### PR TITLE
Fix Prisma seed command for cross-platform compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "vercel-build": "prisma generate --schema=prisma/schema.prisma && prisma migrate deploy --schema=prisma/schema.prisma && next build"
   },
   "prisma": {
-    "seed": "ts-node --compiler-options '{\"module\":\"commonjs\",\"moduleResolution\":\"node\"}' prisma/seed.ts"
+    "seed": "ts-node --project tsconfig.seed.json prisma/seed.ts"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/tsconfig.seed.json
+++ b/tsconfig.seed.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmit": false,
+    "outDir": "./dist-seed"
+  },
+  "include": ["prisma/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add a dedicated tsconfig for Prisma seed scripts that uses CommonJS resolution
- update the Prisma seed command to rely on the new tsconfig instead of inline compiler options

## Testing
- `npx prisma db seed --schema=prisma/schema.prisma` *(fails: missing database connection variables)*

------
https://chatgpt.com/codex/tasks/task_e_68dea50dd38c83338268365d7c5bcdd3